### PR TITLE
chore: fix base overide warning unity

### DIFF
--- a/Assets/Scripts/Characters/Player/PlayerController.cs
+++ b/Assets/Scripts/Characters/Player/PlayerController.cs
@@ -27,7 +27,7 @@ public class PlayerController : CharacterBase
     private float nextAttackTime;
 
     // Initialize player input and action map
-    private void Awake()
+    protected override void Awake()
     {
         base.Awake();
         // Cache component reference

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -680,7 +680,7 @@ PlayerSettings:
   qnxGraphicConfPath: 
   apiCompatibilityLevel: 6
   captureStartupLogs: {}
-  activeInputHandler: 2
+  activeInputHandler: 1
   windowsGamepadBackendHint: 0
   cloudProjectId: 4b4db253-d8e8-478f-941e-7d928ac9945d
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
## Description

fix base override issue in playercontroller

## Changes

<!-- List the main changes -->

- add override keyword to player awake
- removed old input manager from movement options in unity settings

## Related Issues

<!-- Link related issues. Use "Closes #123" to auto-close -->

Closes #

## Type of Change

<!-- Mark with an x -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor/chore

## Testing

<!-- How was this tested? -->

- [x] Tested locally
- [x] No console errors

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Notes

No issue created, was done on the spot.
